### PR TITLE
Add CLI option to only build unreleased part of changelog

### DIFF
--- a/.changelog/unreleased/features/004-build-unreleased.md
+++ b/.changelog/unreleased/features/004-build-unreleased.md
@@ -1,0 +1,3 @@
+* Added a `-u` or `--unreleased` flag to the `build` command to allow for only
+  building the unreleased portion of the changelog
+  ([#4](https://github.com/informalsystems/unclog/pull/4))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -131,9 +131,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "log"
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -241,27 +241,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b5842e81eb9bbea19276a9dbbda22ac042532f390a67ab08b895617978abf3"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "simplelog"
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -404,12 +404,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi",
  "winapi",
 ]
 
@@ -458,9 +457,9 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ unclog add breaking-changes 24-break-the-api
 # Builds your CHANGELOG.md and writes it to stdout.
 unclog build
 
+# Only render unreleased changes (returns an error if none)
+unclog build --unreleased
+
 # Save the output as your new CHANGELOG.md file.
 # NOTE: All logging output goes to stderr.
 unclog build > CHANGELOG.md

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -120,6 +120,7 @@ fn main() {
     };
     if let Err(e) = result {
         log::error!("Failed: {}", e);
+        std::process::exit(1);
     }
 }
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -126,12 +126,12 @@ fn main() {
 
 fn build_changelog<P: AsRef<Path>>(path: P, unreleased: bool) -> Result<()> {
     let changelog = Changelog::read_from_dir(path)?;
-    if unreleased {
-        print!("{}", changelog.render_unreleased()?);
-    } else {
-        print!("{}", changelog.render_full());
-    }
     log::info!("Success!");
+    if unreleased {
+        println!("{}", changelog.render_unreleased()?);
+    } else {
+        println!("{}", changelog.render_full());
+    }
     Ok(())
 }
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -51,11 +51,8 @@ impl Changelog {
         if self.is_empty() {
             paragraphs.push(EMPTY_CHANGELOG_MSG.to_owned());
         } else {
-            if let Some(unreleased) = self.unreleased.as_ref() {
-                if !unreleased.is_empty() {
-                    paragraphs.push(UNRELEASED_HEADING.to_owned());
-                    paragraphs.push(unreleased.to_string());
-                }
+            if let Ok(unreleased_paragraphs) = self.unreleased_paragraphs() {
+                paragraphs.extend(unreleased_paragraphs);
             }
             self.releases
                 .iter()
@@ -65,6 +62,20 @@ impl Changelog {
             }
         }
         paragraphs.join("\n\n")
+    }
+
+    /// Renders just the unreleased changes to a string.
+    pub fn render_unreleased(&self) -> Result<String> {
+        Ok(self.unreleased_paragraphs()?.join("\n\n"))
+    }
+
+    fn unreleased_paragraphs(&self) -> Result<Vec<String>> {
+        if let Some(unreleased) = self.unreleased.as_ref() {
+            if !unreleased.is_empty() {
+                return Ok(vec![UNRELEASED_HEADING.to_owned(), unreleased.to_string()]);
+            }
+        }
+        Err(Error::NoUnreleasedEntries)
     }
 
     /// Initialize a new (empty) changelog in the given path.

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -45,6 +45,28 @@ impl Changelog {
             && self.epilogue.as_ref().map_or(true, String::is_empty)
     }
 
+    /// Renders the full changelog to a string.
+    pub fn render_full(&self) -> String {
+        let mut paragraphs = vec![CHANGELOG_HEADING.to_owned()];
+        if self.is_empty() {
+            paragraphs.push(EMPTY_CHANGELOG_MSG.to_owned());
+        } else {
+            if let Some(unreleased) = self.unreleased.as_ref() {
+                if !unreleased.is_empty() {
+                    paragraphs.push(UNRELEASED_HEADING.to_owned());
+                    paragraphs.push(unreleased.to_string());
+                }
+            }
+            self.releases
+                .iter()
+                .for_each(|r| paragraphs.push(r.to_string()));
+            if let Some(epilogue) = self.epilogue.as_ref() {
+                paragraphs.push(epilogue.clone());
+            }
+        }
+        paragraphs.join("\n\n")
+    }
+
     /// Initialize a new (empty) changelog in the given path.
     ///
     /// Creates the target folder if it doesn't exist, and optionally copies an
@@ -192,24 +214,7 @@ impl Changelog {
 
 impl fmt::Display for Changelog {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut paragraphs = vec![CHANGELOG_HEADING.to_owned()];
-        if self.is_empty() {
-            paragraphs.push(EMPTY_CHANGELOG_MSG.to_owned());
-        } else {
-            if let Some(unreleased) = self.unreleased.as_ref() {
-                if !unreleased.is_empty() {
-                    paragraphs.push(UNRELEASED_HEADING.to_owned());
-                    paragraphs.push(unreleased.to_string());
-                }
-            }
-            self.releases
-                .iter()
-                .for_each(|r| paragraphs.push(r.to_string()));
-            if let Some(epilogue) = self.epilogue.as_ref() {
-                paragraphs.push(epilogue.clone());
-            }
-        }
-        writeln!(f, "{}", paragraphs.join("\n\n"))
+        writeln!(f, "{}", self.render_full())
     }
 }
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -7,15 +7,17 @@ mod fs_utils;
 mod parsing_utils;
 mod release;
 
-use crate::{Error, Result};
-use log::{debug, info};
-use std::path::{Path, PathBuf};
-use std::{fmt, fs};
-
 pub use change_set::ChangeSet;
 pub use change_set_section::ChangeSetSection;
 pub use entry::Entry;
 pub use release::Release;
+
+use crate::changelog::fs_utils::{ensure_dir, path_to_str, read_to_string_opt, rm_gitkeep};
+use crate::changelog::parsing_utils::{extract_release_version, trim_newlines};
+use crate::{Error, Result};
+use log::{debug, info};
+use std::path::{Path, PathBuf};
+use std::{fmt, fs};
 
 pub const CHANGELOG_HEADING: &str = "# CHANGELOG";
 pub const UNRELEASED_FOLDER: &str = "unreleased";
@@ -88,7 +90,7 @@ impl Changelog {
     ) -> Result<()> {
         let path = path.as_ref();
         // Ensure the desired path exists.
-        fs_utils::ensure_dir(path)?;
+        ensure_dir(path)?;
 
         // Optionally copy an epilogue into the target path.
         let epilogue_path = epilogue_path.as_ref();
@@ -97,8 +99,8 @@ impl Changelog {
             fs::copy(ep, &new_epilogue_path)?;
             info!(
                 "Copied epilogue from {} to {}",
-                fs_utils::path_to_str(ep),
-                fs_utils::path_to_str(&new_epilogue_path),
+                path_to_str(ep),
+                path_to_str(&new_epilogue_path),
             );
         }
         // We want an empty unreleased directory with a .gitkeep file
@@ -132,8 +134,8 @@ impl Changelog {
             .collect::<Result<Vec<Release>>>()?;
         // Sort releases by version in descending order (newest to oldest).
         releases.sort_by(|a, b| a.version.cmp(&b.version).reverse());
-        let epilogue = fs_utils::read_to_string_opt(path.join(EPILOGUE_FILENAME))?
-            .map(|e| parsing_utils::trim_newlines(&e).to_owned());
+        let epilogue =
+            read_to_string_opt(path.join(EPILOGUE_FILENAME))?.map(|e| trim_newlines(&e).to_owned());
         Ok(Self {
             unreleased,
             releases,
@@ -152,17 +154,17 @@ impl Changelog {
     {
         let path = path.as_ref();
         let unreleased_path = path.join(UNRELEASED_FOLDER);
-        fs_utils::ensure_dir(&unreleased_path)?;
+        ensure_dir(&unreleased_path)?;
         let section = section.as_ref();
         let section_path = unreleased_path.join(section);
-        fs_utils::ensure_dir(&section_path)?;
+        ensure_dir(&section_path)?;
         let entry_path = section_path.join(entry_id_to_filename(id));
         // We don't want to overwrite any existing entries
         if fs::metadata(&entry_path).is_ok() {
-            return Err(Error::FileExists(fs_utils::path_to_str(&entry_path)));
+            return Err(Error::FileExists(path_to_str(&entry_path)));
         }
         fs::write(&entry_path, content.as_ref())?;
-        info!("Wrote entry to: {}", fs_utils::path_to_str(&entry_path));
+        info!("Wrote entry to: {}", path_to_str(&entry_path));
         Ok(())
     }
 
@@ -187,38 +189,38 @@ impl Changelog {
         let version = version.as_ref();
 
         // Validate the version
-        let _ = semver::Version::parse(&parsing_utils::extract_release_version(version)?)?;
+        let _ = semver::Version::parse(&extract_release_version(version)?)?;
 
         let version_path = path.join(version);
         // The target version path must not yet exist
         if fs::metadata(&version_path).is_ok() {
-            return Err(Error::DirExists(fs_utils::path_to_str(&version_path)));
+            return Err(Error::DirExists(path_to_str(&version_path)));
         }
 
         let unreleased_path = path.join(UNRELEASED_FOLDER);
         // The unreleased folder must exist
         if fs::metadata(&unreleased_path).is_err() {
-            return Err(Error::ExpectedDir(fs_utils::path_to_str(&unreleased_path)));
+            return Err(Error::ExpectedDir(path_to_str(&unreleased_path)));
         }
 
         fs::rename(&unreleased_path, &version_path)?;
         info!(
             "Moved {} to {}",
-            fs_utils::path_to_str(&unreleased_path),
-            fs_utils::path_to_str(&version_path)
+            path_to_str(&unreleased_path),
+            path_to_str(&version_path)
         );
         // We no longer need a .gitkeep in the release directory, if there is one
-        fs_utils::rm_gitkeep(&version_path)?;
+        rm_gitkeep(&version_path)?;
 
         Self::init_empty_unreleased_dir(path)
     }
 
     fn init_empty_unreleased_dir(path: &Path) -> Result<()> {
         let unreleased_dir = path.join(UNRELEASED_FOLDER);
-        fs_utils::ensure_dir(&unreleased_dir)?;
+        ensure_dir(&unreleased_dir)?;
         let unreleased_gitkeep = unreleased_dir.join(".gitkeep");
         fs::write(&unreleased_gitkeep, "")?;
-        debug!("Wrote {}", fs_utils::path_to_str(&unreleased_gitkeep));
+        debug!("Wrote {}", path_to_str(&unreleased_gitkeep));
         Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,4 +25,6 @@ pub enum Error {
     InvalidEntryId(String),
     #[error("failed to parse entry ID as a number")]
     InvalidEntryNumber(#[from] std::num::ParseIntError),
+    #[error("no unreleased entries yet")]
+    NoUnreleasedEntries,
 }


### PR DESCRIPTION
Adds:

```bash
> unclog build --unreleased

# or

> unclog build -u
```

This renders just the unreleased portion of the changelog.