### PR TITLE
Improve error reporting for I/O and subprocess errors

### DIFF
--- a/src/changelog/change_set.rs
+++ b/src/changelog/change_set.rs
@@ -76,13 +76,13 @@ impl ChangeSet {
     }
 }
 
-fn change_set_section_filter(e: fs::DirEntry) -> Option<Result<PathBuf>> {
-    let meta = match e.metadata() {
+fn change_set_section_filter(entry: fs::DirEntry) -> Option<Result<PathBuf>> {
+    let meta = match entry.metadata() {
         Ok(m) => m,
-        Err(e) => return Some(Err(Error::Io(e))),
+        Err(e) => return Some(Err(Error::Io(entry.path(), e))),
     };
     if meta.is_dir() {
-        Some(Ok(e.path()))
+        Some(Ok(entry.path()))
     } else {
         None
     }

--- a/src/changelog/component_section.rs
+++ b/src/changelog/component_section.rs
@@ -81,13 +81,13 @@ impl ComponentSection {
     }
 }
 
-pub(crate) fn package_section_filter(e: fs::DirEntry) -> Option<Result<PathBuf>> {
-    let meta = match e.metadata() {
+pub(crate) fn package_section_filter(entry: fs::DirEntry) -> Option<Result<PathBuf>> {
+    let meta = match entry.metadata() {
         Ok(m) => m,
-        Err(e) => return Some(Err(Error::Io(e))),
+        Err(e) => return Some(Err(Error::Io(entry.path(), e))),
     };
     if meta.is_dir() {
-        Some(Ok(e.path()))
+        Some(Ok(entry.path()))
     } else {
         None
     }

--- a/src/changelog/config.rs
+++ b/src/changelog/config.rs
@@ -123,7 +123,7 @@ impl Config {
             path.display()
         );
         let content = toml::to_string_pretty(&self).map_err(Error::TomlSerialize)?;
-        std::fs::write(path, content)?;
+        std::fs::write(path, content).map_err(|e| Error::Io(path.to_path_buf(), e))?;
         info!("Saved configuration to: {}", path.display());
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,8 +6,10 @@ use thiserror::Error;
 /// All error variants that can be produced by unclog.
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
+    #[error("I/O error relating to {0}: {1}")]
+    Io(PathBuf, std::io::Error),
+    #[error("failed to execute subprocess {0}: {1}")]
+    Subprocess(String, std::io::Error),
     #[error("expected path to be a directory: {0}")]
     ExpectedDir(String),
     #[error("unexpected release directory name prefix: \"{0}\"")]


### PR DESCRIPTION
Relates to #31.

On my machine I started getting the same error, so I made the I/O and subprocess error output more elaborate and got the following:

```
21:47:42 [INFO] Attempting to load configuration file from: .changelog/config.toml
21:47:42 [ERROR] Failed: failed to execute subprocess /usr/bin/nvim: No such file or directory (os error 2)
```

On my machine I'd set my `EDITOR` environment variable to `/usr/bin/nvim`, but recently I started using Homebrew for Linux and my new Neovim executable is located elsewhere :facepalm: 

@shonfeder perhaps this will shed some light on where your error's coming from?