### PR TITLE
Escape the # sign that precedes the issue number in the md file

### DIFF
--- a/.changelog/unreleased/bug-fixes/38-escape-hash-sign.md
+++ b/.changelog/unreleased/bug-fixes/38-escape-hash-sign.md
@@ -1,0 +1,2 @@
+- Escape # in issue or PR  number.
+  ([\#38](https://github.com/informalsystems/unclog/issues/38))

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -29,7 +29,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const DEFAULT_CHANGE_TEMPLATE: &str =
-    "{{{ bullet }}} {{{ message }}} ([#{{ change_id }}]({{{ change_url }}}))";
+    "{{{ bullet }}} {{{ message }}} ([\\#{{ change_id }}]({{{ change_url }}}))";
 
 /// A log of changes for a specific project.
 #[derive(Debug, Clone)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -39,8 +39,8 @@ fn change_template_rendering() {
     init_logger();
     let config = Config::read_from_file("./tests/full/config.toml").unwrap();
     let cases = vec![
-        (PlatformId::Issue(123), "- This introduces a new *breaking* change\n  ([#123](https://github.com/org/project/issues/123))"),
-        (PlatformId::PullRequest(23), "- This introduces a new *breaking* change\n  ([#23](https://github.com/org/project/pull/23))"),
+        (PlatformId::Issue(123), "- This introduces a new *breaking* change\n  ([\\#123](https://github.com/org/project/issues/123))"),
+        (PlatformId::PullRequest(23), "- This introduces a new *breaking* change\n  ([\\#23](https://github.com/org/project/pull/23))"),
     ];
     for (platform_id, expected) in cases {
         let actual = Changelog::render_unreleased_entry_from_template(


### PR DESCRIPTION
Closes #38

The PR fails a test because of issue https://github.com/actions-rs/clippy-check/issues/2, not related to the PR itself.