### PR TITLE
chore: Fix clippy lints

### DIFF
--- a/src/changelog/config.rs
+++ b/src/changelog/config.rs
@@ -106,8 +106,9 @@ impl Config {
         );
         let maybe_content = read_to_string_opt(path)?;
         match maybe_content {
-            Some(content) => toml::from_str::<Self>(&content)
-                .map_err(|e| Error::TomlParse(path_to_str(&path), e)),
+            Some(content) => {
+                toml::from_str::<Self>(&content).map_err(|e| Error::TomlParse(path_to_str(path), e))
+            }
             None => {
                 info!("No changelog configuration file. Assuming defaults.");
                 Ok(Self::default())

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,9 +67,9 @@ pub enum Error {
     #[error("configuration is missing a project URL (needed for automatic entry generation)")]
     MissingProjectUrl,
     #[error("error loading Handlebars template: {0}")]
-    HandlebarsTemplateLoad(#[from] handlebars::TemplateError),
+    HandlebarsTemplateLoad(String),
     #[error("error rendering Handlebars template: {0}")]
-    HandlebarsTemplateRender(#[from] handlebars::RenderError),
+    HandlebarsTemplateRender(String),
     #[error("git error: {0}")]
     Git(#[from] git2::Error),
     #[error("configuration file already exists: {0}")]

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -76,7 +76,7 @@ pub fn get_relative_path<P: AsRef<Path>, Q: AsRef<Path>>(path: P, prefix: Q) -> 
 
 pub fn file_exists<P: AsRef<Path>>(path: P) -> bool {
     let path = path.as_ref();
-    if let Ok(meta) = fs::metadata(&path) {
+    if let Ok(meta) = fs::metadata(path) {
         return meta.is_file();
     }
     false
@@ -84,7 +84,7 @@ pub fn file_exists<P: AsRef<Path>>(path: P) -> bool {
 
 pub fn dir_exists<P: AsRef<Path>>(path: P) -> bool {
     let path = path.as_ref();
-    if let Ok(meta) = fs::metadata(&path) {
+    if let Ok(meta) = fs::metadata(path) {
         return meta.is_dir();
     }
     false


### PR DESCRIPTION
Fixes all the clippy lints for the latest version of Rust (1.66.1).

This is breaking because it changes two of the error variants.