### PR TITLE
Make version a positional argument for `unclog release`

### DIFF
--- a/.changelog/unreleased/breaking-changes/60-release-version-flag.md
+++ b/.changelog/unreleased/breaking-changes/60-release-version-flag.md
@@ -1,0 +1,3 @@
+- When calling `unclog release`, the `--version` flag has been removed and
+  has become a mandatory positional argument, e.g. `unclog release v0.1.0`
+  ([\#60](https://github.com/informalsystems/unclog/pull/60))

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ unclog --help
 ```bash
 # Moves all entries in your ".changelog/unreleased" folder to
 # ".changelog/v0.2.0" and ensures the ".changelog/unreleased" folder is empty.
-unclog release --version v0.2.0
+unclog release v0.2.0
 ```
 
 ### Components/Submodules

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -137,7 +137,6 @@ enum Command {
         editor: PathBuf,
 
         /// The version string to use for the new release (e.g. "v0.1.0").
-        #[arg(long)]
         version: String,
     },
 }


### PR DESCRIPTION
Removes the `--version` flag and turns it into a mandatory positional argument.

```bash
# Old usage
unclog release --version v0.2.0

# New usage
unclog release v0.2.0
```