### PR TITLE
ci: Enable merge group trigger

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,7 @@
 name: Rust
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
It seems we need to enable this in order for merge queues to work.