### PR TITLE
Local changelog duplicate detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "comfy-table"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
+dependencies = [
+ "crossterm",
+ "strum",
+ "strum_macros",
+ "unicode-width",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +218,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -521,6 +555,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +617,29 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -703,10 +770,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -777,6 +856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
 name = "smawk"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +872,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.28",
+]
 
 [[package]]
 name = "syn"
@@ -959,6 +1063,7 @@ version = "0.6.0"
 dependencies = [
  "chrono",
  "clap",
+ "comfy-table",
  "env_logger",
  "git2",
  "handlebars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ simplelog = { version = "0.12", optional = true }
 clap = { version = "4.4", features = ["derive", "env"], optional = true }
 tempfile = { version = "3.8", optional = true }
 chrono = "0.4.31"
+comfy-table = "7.1.0"
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -33,7 +33,7 @@ const DEFAULT_CHANGE_TEMPLATE: &str =
     "{{{ bullet }}} {{{ message }}} ([\\#{{ change_id }}]({{{ change_url }}}))";
 
 /// A log of changes for a specific project.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Changelog {
     /// Unreleased changes don't have version information associated with them.
     pub maybe_unreleased: Option<ChangeSet>,

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -6,6 +6,7 @@ mod component;
 mod component_section;
 pub mod config;
 mod entry;
+mod entry_path;
 mod parsing_utils;
 mod release;
 
@@ -14,6 +15,9 @@ pub use change_set_section::ChangeSetSection;
 pub use component::Component;
 pub use component_section::ComponentSection;
 pub use entry::Entry;
+pub use entry_path::{
+    ChangeSetComponentPath, ChangeSetSectionPath, EntryChangeSetPath, EntryPath, EntryReleasePath,
+};
 pub use release::Release;
 use serde_json::json;
 
@@ -26,14 +30,17 @@ use crate::vcs::{from_git_repo, try_from, GenericProject};
 use crate::{Error, PlatformId, Result};
 use config::Config;
 use log::{debug, info, warn};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use self::change_set::ChangeSetIter;
 
 const DEFAULT_CHANGE_TEMPLATE: &str =
     "{{{ bullet }}} {{{ message }}} ([\\#{{ change_id }}]({{{ change_url }}}))";
 
 /// A log of changes for a specific project.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Changelog {
     /// Unreleased changes don't have version information associated with them.
     pub maybe_unreleased: Option<ChangeSet>,
@@ -486,6 +493,143 @@ impl Changelog {
         fs::write(&unreleased_gitkeep, "").map_err(|e| Error::Io(unreleased_gitkeep.clone(), e))?;
         debug!("Wrote {}", path_to_str(&unreleased_gitkeep));
         Ok(())
+    }
+
+    /// Facilitates iteration through all entries in this changelog, producing
+    /// [`EntryPath`] instances such that one can trace the full path to each
+    /// entry. The order in which entries are produced is the order in which
+    /// they will be rendered if the changelog is built.
+    pub fn entries(&self) -> ChangelogEntryIter<'_> {
+        if let Some(unreleased) = &self.maybe_unreleased {
+            if let Some(change_set_iter) = ChangeSetIter::new(unreleased) {
+                return ChangelogEntryIter {
+                    changelog: self,
+                    state: ChangelogEntryIterState::Unreleased(change_set_iter),
+                };
+            }
+        }
+        if let Some(releases_iter) = ReleasesIter::new(self) {
+            ChangelogEntryIter {
+                changelog: self,
+                state: ChangelogEntryIterState::Released(releases_iter),
+            }
+        } else {
+            ChangelogEntryIter {
+                changelog: self,
+                state: ChangelogEntryIterState::Empty,
+            }
+        }
+    }
+
+    /// Returns a list of entries that are the same across releases within this
+    /// changelog. Effectively compares just the entries themselves without
+    /// regard for the release, section, component, etc.
+    pub fn find_duplicates_across_releases(&self) -> Vec<(EntryPath<'_>, EntryPath<'_>)> {
+        let mut dups = Vec::new();
+        let mut already_found = HashSet::new();
+
+        for path_a in self.entries() {
+            for path_b in self.entries() {
+                if path_a == path_b {
+                    continue;
+                }
+                if path_a.entry() == path_b.entry() && !already_found.contains(&(path_a, path_b)) {
+                    dups.push((path_a, path_b));
+                    already_found.insert((path_a, path_b));
+                    already_found.insert((path_b, path_a));
+                }
+            }
+        }
+        dups
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ChangelogEntryIter<'a> {
+    changelog: &'a Changelog,
+    state: ChangelogEntryIterState<'a>,
+}
+
+impl<'a> Iterator for ChangelogEntryIter<'a> {
+    type Item = EntryPath<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let entry_release_path = self.state.next_entry_path(self.changelog)?;
+        Some(EntryPath {
+            changelog: self.changelog,
+            release_path: entry_release_path,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+enum ChangelogEntryIterState<'a> {
+    Empty,
+    Unreleased(ChangeSetIter<'a>),
+    Released(ReleasesIter<'a>),
+}
+
+impl<'a> ChangelogEntryIterState<'a> {
+    fn next_entry_path(&mut self, changelog: &'a Changelog) -> Option<EntryReleasePath<'a>> {
+        match self {
+            Self::Empty => None,
+            Self::Unreleased(change_set_iter) => match change_set_iter.next() {
+                Some(entry_path) => Some(EntryReleasePath::Unreleased(entry_path)),
+                None => {
+                    *self = ChangelogEntryIterState::Released(ReleasesIter::new(changelog)?);
+                    self.next_entry_path(changelog)
+                }
+            },
+            Self::Released(releases_iter) => {
+                let (release, entry_path) = releases_iter.next()?;
+                Some(EntryReleasePath::Released(release, entry_path))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ReleasesIter<'a> {
+    releases: &'a Vec<Release>,
+    id: usize,
+    // Change set iterator for the current release.
+    change_set_iter: ChangeSetIter<'a>,
+}
+
+impl<'a> ReleasesIter<'a> {
+    fn new(changelog: &'a Changelog) -> Option<Self> {
+        let releases = &changelog.releases;
+        let first_release = releases.get(0)?;
+        Some(Self {
+            releases,
+            id: 0,
+            change_set_iter: ChangeSetIter::new(&first_release.changes)?,
+        })
+    }
+}
+
+impl<'a> Iterator for ReleasesIter<'a> {
+    type Item = (&'a Release, EntryChangeSetPath<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut release = self.releases.get(self.id)?;
+        match self.change_set_iter.next() {
+            Some(entry_path) => Some((release, entry_path)),
+            None => {
+                let mut maybe_change_set_iter = None;
+                while maybe_change_set_iter.is_none() {
+                    self.id += 1;
+                    release = self.releases.get(self.id)?;
+                    maybe_change_set_iter = ChangeSetIter::new(&release.changes);
+                }
+                // Safety: the above while loop will cause the function to exit
+                // if we run out of releases. The while loop will only otherwise
+                // terminate and hit this line if
+                // maybe_change_set_iter.is_none() is false.
+                self.change_set_iter = maybe_change_set_iter.unwrap();
+                self.next()
+            }
+        }
     }
 }
 

--- a/src/changelog/change_set.rs
+++ b/src/changelog/change_set.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 /// A set of changes, either associated with a release or not.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ChangeSet {
     /// An optional high-level summary of the set of changes.
     pub maybe_summary: Option<String>,

--- a/src/changelog/change_set.rs
+++ b/src/changelog/change_set.rs
@@ -1,12 +1,14 @@
 use crate::changelog::fs_utils::{read_and_filter_dir, read_to_string_opt};
 use crate::changelog::parsing_utils::trim_newlines;
-use crate::{ChangeSetSection, Config, Error, Result};
+use crate::{ChangeSetSection, Config, EntryChangeSetPath, Error, Result};
 use log::debug;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use super::change_set_section::ChangeSetSectionIter;
+
 /// A set of changes, either associated with a release or not.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ChangeSet {
     /// An optional high-level summary of the set of changes.
     pub maybe_summary: Option<String>,
@@ -73,6 +75,52 @@ impl ChangeSet {
             .filter(|s| !s.is_empty())
             .for_each(|s| paragraphs.push(s.render(config)));
         paragraphs.join("\n\n")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ChangeSetIter<'a> {
+    change_set: &'a ChangeSet,
+    section_id: usize,
+    section_iter: ChangeSetSectionIter<'a>,
+}
+
+impl<'a> ChangeSetIter<'a> {
+    pub(crate) fn new(change_set: &'a ChangeSet) -> Option<Self> {
+        let first_section = change_set.sections.get(0)?;
+        Some(Self {
+            change_set,
+            section_id: 0,
+            section_iter: ChangeSetSectionIter::new(first_section)?,
+        })
+    }
+}
+
+impl<'a> Iterator for ChangeSetIter<'a> {
+    type Item = EntryChangeSetPath<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let _ = self.change_set.sections.get(self.section_id)?;
+        match self.section_iter.next() {
+            Some(section_path) => Some(EntryChangeSetPath {
+                change_set: self.change_set,
+                section_path,
+            }),
+            None => {
+                let mut maybe_section_iter = None;
+                while maybe_section_iter.is_none() {
+                    self.section_id += 1;
+                    let section = self.change_set.sections.get(self.section_id)?;
+                    maybe_section_iter = ChangeSetSectionIter::new(section);
+                }
+                // Safety: the above while loop will cause the function to exit
+                // if we run out of sections. The while loop will only otherwise
+                // terminate and hit this line if maybe_section_iter.is_none()
+                // is false.
+                self.section_iter = maybe_section_iter.unwrap();
+                self.next()
+            }
+        }
     }
 }
 

--- a/src/changelog/change_set_section.rs
+++ b/src/changelog/change_set_section.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 /// A single section in a set of changes.
 ///
 /// For example, the "FEATURES" or "BREAKING CHANGES" section.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ChangeSetSection {
     /// A short, descriptive title for this section (e.g. "BREAKING CHANGES").
     pub title: String,

--- a/src/changelog/component_section.rs
+++ b/src/changelog/component_section.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 /// A section of entries related to a specific component/submodule/package.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ComponentSection {
     /// The ID of the component.
     pub id: String,
@@ -81,6 +81,35 @@ impl ComponentSection {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ComponentSectionIter<'a> {
+    section: &'a ComponentSection,
+    entry_id: usize,
+}
+
+impl<'a> ComponentSectionIter<'a> {
+    pub(crate) fn new(section: &'a ComponentSection) -> Option<Self> {
+        if section.is_empty() {
+            None
+        } else {
+            Some(Self {
+                section,
+                entry_id: 0,
+            })
+        }
+    }
+}
+
+impl<'a> Iterator for ComponentSectionIter<'a> {
+    type Item = &'a Entry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let entry = self.section.entries.get(self.entry_id)?;
+        self.entry_id += 1;
+        Some(entry)
+    }
+}
+
 pub(crate) fn package_section_filter(entry: fs::DirEntry) -> Option<Result<PathBuf>> {
     let meta = match entry.metadata() {
         Ok(m) => m,
@@ -133,14 +162,17 @@ mod test {
     fn test_entries() -> Vec<Entry> {
         vec![
             Entry {
+                filename: "1-issue.md".to_string(),
                 id: 1,
                 details: "- Issue 1".to_string(),
             },
             Entry {
+                filename: "2-issue.md".to_string(),
                 id: 2,
                 details: "- Issue 2".to_string(),
             },
             Entry {
+                filename: "3-issue.md".to_string(),
                 id: 3,
                 details: "- Issue 3".to_string(),
             },

--- a/src/changelog/component_section.rs
+++ b/src/changelog/component_section.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 /// A section of entries related to a specific component/submodule/package.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ComponentSection {
     /// The ID of the component.
     pub id: String,

--- a/src/changelog/entry.rs
+++ b/src/changelog/entry.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use super::config::SortEntriesBy;
 
 /// A single entry in a set of changes.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Entry {
     /// The issue/pull request ID relating to this entry.
     pub id: u64,

--- a/src/changelog/entry_path.rs
+++ b/src/changelog/entry_path.rs
@@ -1,0 +1,100 @@
+use std::path::PathBuf;
+
+use crate::{ChangeSet, ChangeSetSection, Changelog, ComponentSection, Config, Entry, Release};
+
+/// Provides a precise path through a specific changelog to a specific entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EntryPath<'a> {
+    pub changelog: &'a Changelog,
+    pub release_path: EntryReleasePath<'a>,
+}
+
+impl<'a> EntryPath<'a> {
+    /// Reconstructs the filesystem path, relative to the changelog folder path,
+    /// for this particular entry.
+    pub fn as_path(&self, config: &Config) -> PathBuf {
+        self.release_path.as_path(config)
+    }
+
+    pub fn entry(&self) -> &'a Entry {
+        self.release_path.entry()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EntryReleasePath<'a> {
+    Unreleased(EntryChangeSetPath<'a>),
+    Released(&'a Release, EntryChangeSetPath<'a>),
+}
+
+impl<'a> EntryReleasePath<'a> {
+    pub fn as_path(&self, config: &Config) -> PathBuf {
+        match self {
+            Self::Unreleased(p) => PathBuf::from(&config.unreleased.folder).join(p.as_path()),
+            Self::Released(r, p) => PathBuf::from(&r.id).join(p.as_path()),
+        }
+    }
+
+    pub fn entry(&self) -> &'a Entry {
+        match self {
+            Self::Unreleased(change_set_path) => change_set_path.entry(),
+            Self::Released(_, change_set_path) => change_set_path.entry(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EntryChangeSetPath<'a> {
+    pub change_set: &'a ChangeSet,
+    pub section_path: ChangeSetSectionPath<'a>,
+}
+
+impl<'a> EntryChangeSetPath<'a> {
+    pub fn as_path(&self) -> PathBuf {
+        self.section_path.as_path()
+    }
+
+    pub fn entry(&self) -> &'a Entry {
+        self.section_path.entry()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ChangeSetSectionPath<'a> {
+    pub change_set_section: &'a ChangeSetSection,
+    pub component_path: ChangeSetComponentPath<'a>,
+}
+
+impl<'a> ChangeSetSectionPath<'a> {
+    pub fn as_path(&self) -> PathBuf {
+        PathBuf::from(&self.change_set_section.id).join(self.component_path.as_path())
+    }
+
+    pub fn entry(&self) -> &'a Entry {
+        self.component_path.entry()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChangeSetComponentPath<'a> {
+    General(&'a Entry),
+    Component(&'a ComponentSection, &'a Entry),
+}
+
+impl<'a> ChangeSetComponentPath<'a> {
+    pub fn as_path(&self) -> PathBuf {
+        match self {
+            Self::General(entry) => PathBuf::from(&entry.filename),
+            Self::Component(component_section, entry) => {
+                PathBuf::from(&component_section.id).join(&entry.filename)
+            }
+        }
+    }
+
+    pub fn entry(&self) -> &'a Entry {
+        match self {
+            Self::General(entry) => entry,
+            Self::Component(_, entry) => entry,
+        }
+    }
+}

--- a/src/changelog/release.rs
+++ b/src/changelog/release.rs
@@ -7,7 +7,7 @@ use log::{debug, warn};
 use std::path::Path;
 
 /// The changes associated with a specific release.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Release {
     /// This release's ID (could be the version plus a prefix, e.g. `v0.1.0`).
     pub id: String,

--- a/src/changelog/release.rs
+++ b/src/changelog/release.rs
@@ -7,7 +7,7 @@ use log::{debug, warn};
 use std::path::Path;
 
 /// The changes associated with a specific release.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Release {
     /// This release's ID (could be the version plus a prefix, e.g. `v0.1.0`).
     pub id: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@ pub use changelog::config::{
     BulletStyle, ChangeSetsConfig, ComponentsConfig, Config, UnreleasedConfig,
 };
 pub use changelog::{
-    ChangeSet, ChangeSetSection, Changelog, Component, ComponentSection, Entry, Release,
+    ChangeSet, ChangeSetComponentPath, ChangeSetSection, ChangeSetSectionPath, Changelog,
+    Component, ComponentSection, Entry, EntryChangeSetPath, EntryPath, EntryReleasePath, Release,
 };
 pub use error::Error;
 pub use vcs::{GenericProject, PlatformId, Project};


### PR DESCRIPTION
Partially addresses #81.

This only implements `unclog find-duplicates`, which allows you to list all the entries on your local Git repo branch that are duplicates.

A separate PR will be needed to implement the functionality to find duplicates _across_ branches.