### PR TITLE
Condense output of find-duplicates subcommand

### DIFF
--- a/.changelog/unreleased/enhancements/153-condense-find-dups-output.md
+++ b/.changelog/unreleased/enhancements/153-condense-find-dups-output.md
@@ -1,0 +1,4 @@
+- Condense `find-duplicates` output by not outputting `.changelog`
+  directory path by default. To include the `.changelog` folder path,
+  use the `--include-changelog-path` flag when calling `find-duplicates`
+  ([\#153](https://github.com/informalsystems/unclog/pull/153))


### PR DESCRIPTION
The `find-duplicates` subcommand always outputs the full path of both entries, including the `.changelog` folder path, which seems redundant and makes the output a little less readable.

This PR removes this behaviour, and adds it behind a flag if you really do want the full path to the changelog.